### PR TITLE
Add a netsh alternative for windows

### DIFF
--- a/dnscfg/_base.py
+++ b/dnscfg/_base.py
@@ -31,7 +31,9 @@ def create_dnscfg():
             from dnscfg.windows_dnscfg import WindowsDNSCfg
             return WindowsDNSCfg()
         except:
-            from dnscfg.windows_netsh_dnscfg import WindowsNetshDNSCfg
+			print 'wmi method not working try netsh'
+		    from dnscfg.windows_netsh_dnscfg import WindowsNetshDNSCfg
+		    return WindowsNetshDNSCfg()
     else:
         print "Unsuppoerted os"
         

--- a/dnscfg/windows_dnscfg.py
+++ b/dnscfg/windows_dnscfg.py
@@ -13,7 +13,7 @@ class WindowsDNSCfg:
 	def __init__(self):
 		self.wmiService = wmi.WMI()
 		self.netCfgBackup={}
-		self.notadmin = self.GetDNSBackup()
+		self.notadmin = self.backup()
 	#----------------------------------------------------------------------
 	# Get the Adapter who has mac from wmi 
 	#----------------------------------------------------------------------
@@ -42,7 +42,7 @@ class WindowsDNSCfg:
 				except:
 					pass
 		if flag:
-			self.RestoreDns()
+			self.restore()
 		return False
 	#----------------------------------------------------------------------
 	# Modify DNS

--- a/dnscfg/windows_netsh_dnscfg.py
+++ b/dnscfg/windows_netsh_dnscfg.py
@@ -1,14 +1,79 @@
+﻿#! /usr/bin/python
+# -*- coding: utf-8 -*-
+# FileName: windows_netsh_dnscfg.py
+# Author  : davidaq
+# Email   : aq@num16.com
+# Date    : 2013-03-07
 from dnscfg import DNSCfg
-
+import os
+import subprocess
+import re
+########################################################################
 class WindowsNetshDNSCfg(DNSCfg):
     def backup(self):
-        pass
+        file = None
+        try:
+            raw_result = subprocess.check_output('netsh interface ip show dns')
+            ip = re.compile(r'\d+\.\d+\.\d+\.\d+')
+            result = {}
+            for interface in self.interfaces():
+                pos = raw_result.find('"' + interface + '"')
+                pos = raw_result.find('\n', pos) + 1
+                end = raw_result.find('\n', pos)
+                line = raw_result[pos:end]
+                result[interface] = 'auto'
+                if 'DHCP' not in line and 'dhcp' not in line:
+                    match = ip.search(line)
+                    if match != None:
+                        result[interface] = match.group()
+            file = open(self.backupfile(), 'w')
+            file.write(repr(result))
+        except:
+            print 'failed to backup'
+            return True
+        finally:
+            if file != None:
+                file.close()
     
     def modify(self, dns):
-        print dns
+        cmd = ['pushd interface ip']
+        for interface in self.interfaces():
+            cmd.append('set dns "' + interface + '" source=static addr=' + dns + ' register=PRIMARY')
+        cmd.append('popd\n')
+        process = subprocess.Popen('netsh', stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        process.communicate('\n'.join(cmd))
 
     def restore(self):
-        pass
+        file = None
+        try:
+            file = open(self.backupfile(), 'r')
+            backup = file.read()
+        except:
+            return True
+        backup = eval(backup)
+        cmd = ['pushd interface ip']
+        for interface in backup.keys():
+            if backup[interface] == 'auto':
+                cmd.append('set dns "' + interface + '" source=dhcp register=PRIMARY')
+            else:
+                cmd.append('set dns "' + interface + '" source=static addr=' + backup[interface] + ' register=PRIMARY')
+        cmd.append('popd\n')
+        process = subprocess.Popen('netsh', stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        process.communicate('\n'.join(cmd))
     
+    def backupfile(self):
+        return os.path.expanduser('~') + os.path.sep + 'puredns_backup.log'
+        
+    def interfaces(self):
+        raw_result = subprocess.check_output('netsh interface ip show interfaces')
+        result = []
+        token = ' connected'
+        for line in raw_result.split('\n'):
+            pos = line.find(token)
+            if pos > -1:
+                item = line[pos + len(token):].strip()
+                result.append(item)
+        return result
+        
 def printinfo():
     print 'None'

--- a/loader/windows_loader.py
+++ b/loader/windows_loader.py
@@ -3,13 +3,13 @@
 # FileName: PureDNS.py
 # Author  : xiaoyao9933
 # Email   : me@chao.lu
-# Date    : 2013-02-14
-# Vesion  : 1.2
+# Date    : 2013-03-06
+# Vesion  : 1.3
 import wx
 import webbrowser
 import time
-import tcpdns
 import _winreg
+from server.tcpdns import TCPDNS
 import os,sys,traceback 
 import signal 
 ########################################################################
@@ -18,15 +18,15 @@ class Icon(wx.TaskBarIcon):
     TBMENU_CLOSE   = wx.NewId()
     TBMENU_ABOUT  = wx.NewId()
     state=False
-    version = '1.2'
+    version = '1.3'
     #----------------------------------------------------------------------
     def __init__(self,serv,dnscfg):
         wx.TaskBarIcon.__init__(self)
         self.menu = wx.Menu()
-        self.menu.Append(self.TBMENU_SERVICE, "¿ØÖÆ´úÀí")
-        self.menu.Append(self.TBMENU_ABOUT, "°ïÖú PureDNS" + self.version)
+        self.menu.Append(self.TBMENU_SERVICE, "NULL")
+        self.menu.Append(self.TBMENU_ABOUT, u"关于 PureDNS" + self.version)
         self.menu.AppendSeparator()
-        self.menu.Append(self.TBMENU_CLOSE,   "ÍË³ö")
+        self.menu.Append(self.TBMENU_CLOSE, u"退出程序")
 		# Set the image
         self.tbIcon = wx.EmptyIcon()
         self.tbIcon.LoadFile(resource_path("PureDNS.ico"),wx.BITMAP_TYPE_ICO) 
@@ -38,29 +38,31 @@ class Icon(wx.TaskBarIcon):
         self.Bind(wx.EVT_CLOSE, self.OnClose)
         self.Bind(wx.EVT_TASKBAR_LEFT_DOWN, self.OnTaskBarClick)
         self.Bind(wx.EVT_TASKBAR_RIGHT_DOWN, self.OnTaskBarClick)
-        self.serv = serv 
-        self.serv.start()
+        self.serv = serv
+        print 'there1'
+        self.serv.run()
         self.dnscfg = dnscfg
         time.sleep(1)
+        print 'there'
         if self.serv.server:
             self.state = True
             self.dnscfg.modify('127.0.0.1')
-            self.menu.SetLabel(self.TBMENU_SERVICE,'Í£Ö¹DNS´úÀí')
+            self.menu.SetLabel(self.TBMENU_SERVICE,u'停用DNS代理')
         else:
             self.state = False
-            wx.MessageDialog(None,'ÒÑ¾­ÓÐÆäËû½ø³ÌÕ¼ÓÃ53¶Ë¿Ú','´íÎó',wx.OK).ShowModal()
-            self.menu.SetLabel(self.TBMENU_SERVICE,'Æô¶¯DNS´úÀí') 
+            wx.MessageDialog(None,u'端口号53已经被占用',u'错误',wx.OK).ShowModal()
+            self.menu.SetLabel(self.TBMENU_SERVICE,u'启动DNS代理') 
 
     #----------------------------------------------------------------------
     def OnTaskBarSevice(self,evt):
         if self.state is False:
             self.dnscfg.modify('127.0.0.1')
             self.state=True
-            self.menu.SetLabel(self.TBMENU_SERVICE,'Í£Ö¹DNS´úÀí')
+            self.menu.SetLabel(self.TBMENU_SERVICE,u'停用DNS代理')
         else:
-            self.dnscfg.modify()
+            self.dnscfg.restore()
             self.state=False
-            self.menu.SetLabel(self.TBMENU_SERVICE,'Æô¶¯DNS´úÀí')         
+            self.menu.SetLabel(self.TBMENU_SERVICE,u'启动DNS代理')         
  
     #----------------------------------------------------------------------
     def OnTaskBarActivateD(self, evt):
@@ -101,20 +103,20 @@ class Frame(wx.Frame):
 
         
 class App(wx.App):
-    def __init__(self, logfile,notadmin,redirect=False, filename=None, cfg=None):
-        wx.App.__init__(self, redirect, filename)
+    def __init__(self, logfile,notadmin,cfg,redirect=False, filename=None):
         self.logfile=logfile
         self.notadmin = notadmin
         self.hdnscfg = cfg
+        wx.App.__init__(self, redirect, filename)
 
     def OnInit(self):
-        if notadmin:
-            wx.MessageDialog(None,'ÇëÒÔ¹ÜÀíÔ±È¨ÏÞÖ´ÐÐ±¾³ÌÐò','´íÎó',wx.OK).ShowModal()
+        if False:
+            wx.MessageDialog(None,u'请以管理员权限运行本程序',u'错误',wx.OK).ShowModal()
             self.ExitMainLoop()
             return True
-        self.htcpdns = tcpdns.tcpdns()
-        if self.hdnscfg.notadmin:
-            wx.MessageDialog(None,'ÇëÒÔ¹ÜÀíÔ±È¨ÏÞÖ´ÐÐ±¾³ÌÐò','´íÎó',wx.OK).ShowModal()
+        self.htcpdns = TCPDNS(self.hdnscfg)
+        if self.notadmin:
+            wx.MessageDialog(None,u'请以管理员权限运行本程序',u'错误',wx.OK).ShowModal()
             self.htcpdns.force_close()
             self.ExitMainLoop()
             return True
@@ -169,7 +171,7 @@ def load(cfg):
             traceback.print_exc()
             #DNSCfg.PrintInfo()
             logfile.flush()
-            wx.MessageDialog(None,'·¢ÉúÖÂÃü´íÎó£¬Çë½«ÓëÈí¼þÍ¬Ä¿Â¼ÏÂµÄ log.txt ·¢µ½ puredns@chao.lu,Ð­ÖúÎÒÍêÉÆ³ÌÐò£¬¶àÐ»!','´íÎó',wx.OK).ShowModal()
+            wx.MessageDialog(None,u'遇到致命错误，请将同目录下的log.txt发送到puredns@chao.lu,多谢!',u'错误',wx.OK).ShowModal()
             
     finally:
         sys.stdout = logfile


### PR DESCRIPTION
**_Add a feature to the configure model for windows.**_
The original method will be used first but if an exception occurs _(since WMI may not work on x64 Win7)_ , the netsh alternative will be used, _No other behaviours are changed_
**_BTW: I'm a friend of mjzshd and he introduced this to me**_
